### PR TITLE
Add workaround to check REAL shell, also improve OS detection

### DIFF
--- a/source/sysinfo-minimal.sh
+++ b/source/sysinfo-minimal.sh
@@ -3,7 +3,7 @@
 # Author : Unix121
 # GitHub : github.com/unix121
 # E-mail : unix121@protonmail.com
-# Description : Simple bash script that displays some 
+# Description : Simple bash script that displays some
 #               system information using the terminal
 #               colors. Designed to be minimalistic and
 #               easy to configure/change.
@@ -19,19 +19,24 @@ printf -v color6 %b "\e[36m"
 bold=$(tput bold)
 normal=$(tput sgr0)
 
+checkshell=$(cat /etc/passwd | grep $USER | cut -c 45-)
+case "$checkshell" in
+  "/usr/bin/zsh") USING=$(zsh --version | cut -c -9) ;;
+  "/usr/bin/bash") USING=$(bash --version | grep "GNU bash, version" | awk {'print $4'}) ;;
+esac
+
 user=$(whoami)
-linux=$(lsb_release -is)
+linux=$(cat /etc/os-release | grep "PRETTY_NAME=" | cut -c 14- | cut -c -10)
 kernel=$(uname -r)
-bash=$BASH_VERSION
+bash=$USING
 wm=$GDMSESSION
 term=$TERM
 
 echo
-echo $color1 ████████████████ ${bold}User:${normal}  $user 
+echo $color1 ████████████████ ${bold}User:${normal}  $user
 echo $color2 ████████████████ ${bold}OS:${normal} $linux
 echo $color3 ████████████████ ${bold}Kernel:${normal} $kernel
-echo $color4 ████████████████ ${bold}Shell:${normal} $BASH_VERSION
+echo $color4 ████████████████ ${bold}Shell:${normal} $USING
 echo $color5 ████████████████ ${bold}WM:${normal} $wm
 echo $color6 ████████████████ ${bold}Terminal:${normal} $term
 echo
-


### PR DESCRIPTION
Hi!
Not all OS have lsb_release, to fix this problem without installing any package i used /etc/os-release and grep REAL name of OS

And added small workaround to check REAL shell. I used /etc/passwd to due small problem:
If we use `echo $0` its return shell(like /usr/bin/bash or /usr/bin/zsh) but script running by bash, and this command will return only bash version.

I liked your script, thanks dude!