### PR TITLE
Fix workaround, and return to lsb_release

### DIFF
--- a/source/sysinfo-minimal.sh
+++ b/source/sysinfo-minimal.sh
@@ -19,14 +19,13 @@ printf -v color6 %b "\e[36m"
 bold=$(tput bold)
 normal=$(tput sgr0)
 
-checkshell=$(cat /etc/passwd | grep $USER | cut -c 45-)
-case "$checkshell" in
+case "$SHELL" in
   "/usr/bin/zsh") USING=$(zsh --version | cut -c -9) ;;
   "/usr/bin/bash") USING=$(bash --version | grep "GNU bash, version" | awk {'print $4'}) ;;
 esac
 
 user=$(whoami)
-linux=$(cat /etc/os-release | grep "PRETTY_NAME=" | cut -c 14- | cut -c -10)
+linux=$(lsb_release -is)
 kernel=$(uname -r)
 bash=$USING
 wm=$GDMSESSION

--- a/source/sysinfo-minimal.sh
+++ b/source/sysinfo-minimal.sh
@@ -20,8 +20,8 @@ bold=$(tput bold)
 normal=$(tput sgr0)
 
 case "$SHELL" in
-  "/usr/bin/zsh") USING=$(zsh --version | cut -c -9) ;;
-  "/usr/bin/bash") USING=$(bash --version | grep "GNU bash, version" | awk {'print $4'}) ;;
+  "/usr/bin/zsh" | "/bin/zsh") USING=$(zsh --version | cut -c -9) ;;
+  "/usr/bin/bash" | "/bin/bash") USING=$(bash --version | grep "GNU bash, version" | awk {'print $4'}) ;;
 esac
 
 user=$(whoami)


### PR DESCRIPTION
To due usage of "cut" we need to return to lsb_release, and maybe add to dependencies, and use $SHELL var to due anoter problem with "cut"